### PR TITLE
Fix: Build failure with Dart 3 and Flutter 3.10 #3

### DIFF
--- a/lib/src/blend_decoration_image.dart
+++ b/lib/src/blend_decoration_image.dart
@@ -18,8 +18,7 @@ import 'package:flutter/material.dart';
 /// This object should be disposed using the [dispose] method when it is no
 /// longer needed.
 class BlendDecorationImagePainter {
-  BlendDecorationImagePainter(this.details, this.onChanged)
-      : assert(details != null);
+  BlendDecorationImagePainter(this.details, this.onChanged);
 
   final DecorationImage details;
   final VoidCallback onChanged;
@@ -43,9 +42,6 @@ class BlendDecorationImagePainter {
   /// will be called.
   void paint(Canvas canvas, Rect rect, Path? clipPath,
       ImageConfiguration configuration, BlendMode blendMode) {
-    assert(canvas != null);
-    assert(rect != null);
-    assert(configuration != null);
 
     bool flipHorizontally = false;
     if (details.matchTextDirection) {
@@ -70,8 +66,9 @@ class BlendDecorationImagePainter {
         }
         return true;
       }());
-      if (configuration.textDirection == TextDirection.rtl)
+      if (configuration.textDirection == TextDirection.rtl) {
         flipHorizontally = true;
+      }
     }
 
     final ImageStream newImageStream = details.image.resolve(configuration);
@@ -121,7 +118,6 @@ class BlendDecorationImagePainter {
     }
     _image?.dispose();
     _image = value;
-    assert(onChanged != null);
     if (!synchronousCall) onChanged();
   }
 
@@ -253,12 +249,6 @@ void paintImage({
   FilterQuality filterQuality = FilterQuality.low,
   bool isAntiAlias = false,
 }) {
-  assert(canvas != null);
-  assert(image != null);
-  assert(alignment != null);
-  assert(repeat != null);
-  assert(flipHorizontally != null);
-  assert(isAntiAlias != null);
   assert(
     image.debugGetOpenHandleStackTraces()?.isNotEmpty ?? true,
     'Cannot paint an image that is disposed.\n'
@@ -322,7 +312,7 @@ void paintImage({
       // It's ok to use this instead of a MediaQuery because if this changes,
       // whatever is aware of the MediaQuery will be repainting the image anyway.
       displaySize:
-          outputSize * PaintingBinding.instance!.window.devicePixelRatio,
+          outputSize * PaintingBinding.instance.window.devicePixelRatio,
     );
     assert(() {
       if (debugInvertOversizedImages &&
@@ -388,7 +378,7 @@ void paintImage({
         _pendingImageSizeInfo[sizeInfo.source!] = sizeInfo;
       }
       debugOnPaintImage?.call(sizeInfo);
-      SchedulerBinding.instance!.addPostFrameCallback((Duration timeStamp) {
+      SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
         _lastFrameImageSizeInfo = _pendingImageSizeInfo.values.toSet();
         if (_pendingImageSizeInfo.isEmpty) {
           return;
@@ -424,8 +414,9 @@ void paintImage({
       canvas.drawImageRect(image, sourceRect, destinationRect, paint);
     } else {
       for (final Rect tileRect
-          in _generateImageTileRects(rect, destinationRect, repeat))
+          in _generateImageTileRects(rect, destinationRect, repeat)) {
         canvas.drawImageRect(image, sourceRect, tileRect, paint);
+      }
     }
   } else {
     canvas.scale(1 / scale);
@@ -434,9 +425,10 @@ void paintImage({
           _scaleRect(destinationRect, scale), paint);
     } else {
       for (final Rect tileRect
-          in _generateImageTileRects(rect, destinationRect, repeat))
+          in _generateImageTileRects(rect, destinationRect, repeat)) {
         canvas.drawImageNine(image, _scaleRect(centerSlice, scale),
             _scaleRect(tileRect, scale), paint);
+      }
     }
   }
   if (needSave) canvas.restore();

--- a/lib/src/box_decoration_mix.dart
+++ b/lib/src/box_decoration_mix.dart
@@ -7,8 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
-import 'package:flutter/painting.dart';
-
 import 'blend_decoration_image.dart';
 
 /// An immutable description of how to paint a box.
@@ -90,8 +88,7 @@ class BoxDecorationMix extends Decoration {
     this.gradient2,
     this.backgroundBlendMode,
     this.shape = BoxShape.rectangle,
-  })  : assert(shape != null),
-        assert(
+  })  : assert(
           backgroundBlendMode == null ||
               color != null ||
               gradient1 != null ||
@@ -217,7 +214,7 @@ class BoxDecorationMix extends Decoration {
   final BoxShape shape;
 
   @override
-  EdgeInsetsGeometry? get padding => border?.dimensions;
+  EdgeInsetsGeometry get padding => border?.dimensions ?? EdgeInsets.zero;
 
   @override
   Path getClipPath(Rect rect, TextDirection textDirection) {
@@ -228,9 +225,10 @@ class BoxDecorationMix extends Decoration {
         final Rect square = Rect.fromCircle(center: center, radius: radius);
         return Path()..addOval(square);
       case BoxShape.rectangle:
-        if (borderRadius != null)
+        if (borderRadius != null) {
           return Path()
             ..addRRect(borderRadius!.resolve(textDirection).toRRect(rect));
+        }
         return Path()..addRect(rect);
     }
   }
@@ -256,13 +254,13 @@ class BoxDecorationMix extends Decoration {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
       color,
       image1,
       image2,
       border,
       borderRadius,
-      hashList(boxShadow),
+      Object.hashAll(boxShadow ?? []),
       gradient1,
       gradient2,
       shape,
@@ -271,7 +269,6 @@ class BoxDecorationMix extends Decoration {
 
   @override
   bool hitTest(Size size, Offset position, {TextDirection? textDirection}) {
-    assert(shape != null);
     assert((Offset.zero & size).contains(position));
     switch (shape) {
       case BoxShape.rectangle:
@@ -299,15 +296,13 @@ class BoxDecorationMix extends Decoration {
 /// An object that paints a [BoxDecorationMix] into a canvas.
 class _BoxDecorationMixPainter extends BoxPainter {
   _BoxDecorationMixPainter(this._decoration, VoidCallback? onChanged)
-      : assert(_decoration != null),
-        super(onChanged);
+      : super(onChanged);
 
   final BoxDecorationMix _decoration;
 
   Paint? _cachedBackgroundPaint1;
   Rect? _rectForCachedBackgroundPaint1;
   Paint _getBackgroundPaint1(Rect rect, TextDirection? textDirection) {
-    assert(rect != null);
     assert(_decoration.gradient1 != null ||
         _rectForCachedBackgroundPaint1 == null);
 
@@ -315,8 +310,9 @@ class _BoxDecorationMixPainter extends BoxPainter {
         (_decoration.gradient1 != null &&
             _rectForCachedBackgroundPaint1 != rect)) {
       final Paint paint = Paint();
-      if (_decoration.backgroundBlendMode != null)
+      if (_decoration.backgroundBlendMode != null) {
         paint.blendMode = _decoration.backgroundBlendMode!;
+      }
       if (_decoration.color != null) paint.color = _decoration.color!;
       if (_decoration.gradient1 != null) {
         paint.shader = _decoration.gradient1!
@@ -332,7 +328,6 @@ class _BoxDecorationMixPainter extends BoxPainter {
   Paint? _cachedBackgroundPaint2;
   Rect? _rectForCachedBackgroundPaint2;
   Paint _getBackgroundPaint2(Rect rect, TextDirection? textDirection) {
-    assert(rect != null);
     assert(_decoration.gradient2 != null ||
         _rectForCachedBackgroundPaint2 == null);
 
@@ -340,8 +335,9 @@ class _BoxDecorationMixPainter extends BoxPainter {
         (_decoration.gradient2 != null &&
             _rectForCachedBackgroundPaint2 != rect)) {
       final Paint paint = Paint();
-      if (_decoration.backgroundBlendMode != null)
+      if (_decoration.backgroundBlendMode != null) {
         paint.blendMode = _decoration.backgroundBlendMode!;
+      }
       if (_decoration.color != null) paint.color = _decoration.color!;
       if (_decoration.gradient2 != null) {
         paint.shader = _decoration.gradient2!
@@ -387,13 +383,15 @@ class _BoxDecorationMixPainter extends BoxPainter {
 
   void _paintBackgroundColor(
       Canvas canvas, Rect rect, TextDirection? textDirection) {
-    if (_decoration.color != null || _decoration.gradient1 != null)
+    if (_decoration.color != null || _decoration.gradient1 != null) {
       _paintBox(canvas, rect, _getBackgroundPaint1(rect, textDirection),
           textDirection);
+    }
 
-    if (_decoration.color != null || _decoration.gradient2 != null)
+    if (_decoration.color != null || _decoration.gradient2 != null) {
       _paintBox(canvas, rect, _getBackgroundPaint2(rect, textDirection),
           textDirection);
+    }
   }
 
   DecorationImagePainter? _imagePainter1;
@@ -411,11 +409,12 @@ class _BoxDecorationMixPainter extends BoxPainter {
         clipPath = Path()..addOval(square);
         break;
       case BoxShape.rectangle:
-        if (_decoration.borderRadius != null)
+        if (_decoration.borderRadius != null) {
           clipPath = Path()
             ..addRRect(_decoration.borderRadius!
                 .resolve(configuration.textDirection)
                 .toRRect(rect));
+        }
         break;
     }
     _imagePainter1!.paint(canvas, rect, clipPath, configuration);
@@ -437,11 +436,12 @@ class _BoxDecorationMixPainter extends BoxPainter {
         clipPath = Path()..addOval(square);
         break;
       case BoxShape.rectangle:
-        if (_decoration.borderRadius != null)
+        if (_decoration.borderRadius != null) {
           clipPath = Path()
             ..addRRect(_decoration.borderRadius!
                 .resolve(configuration.textDirection)
                 .toRRect(rect));
+        }
         break;
     }
     _imagePainter2!
@@ -458,7 +458,6 @@ class _BoxDecorationMixPainter extends BoxPainter {
   /// Paint the box decoration into the given location on the given canvas.
   @override
   void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
-    assert(configuration != null);
     assert(configuration.size != null);
     final Rect rect = offset & configuration.size!;
     final TextDirection? textDirection = configuration.textDirection;

--- a/lib/src/smooth_decoration_tween.dart
+++ b/lib/src/smooth_decoration_tween.dart
@@ -14,9 +14,9 @@ class SmoothDecorationTween extends DecorationTween {
     if (begin is BoxDecoration && end is BoxDecoration) {
       return lerpBoxDecoration(
               begin as BoxDecoration, end as BoxDecoration, t) ??
-          BoxDecoration();
+          const BoxDecoration();
     }
-    return Decoration.lerp(begin, end, t) ?? BoxDecoration();
+    return Decoration.lerp(begin, end, t) ?? const BoxDecoration();
   }
 
   bool _isSameGradient(Gradient a, Gradient b) {
@@ -26,7 +26,6 @@ class SmoothDecorationTween extends DecorationTween {
   }
 
   Decoration? lerpBoxDecoration(BoxDecoration? a, BoxDecoration? b, double t) {
-    assert(t != null);
     if (a == null && b == null) return null;
     if (a == null) return b!.scale(t);
     if (b == null) return a.scale(1.0 - t);
@@ -105,7 +104,7 @@ class SmoothDecorationTween extends DecorationTween {
             BorderRadiusGeometry.lerp(a.borderRadius, b.borderRadius, t),
         boxShadow: BoxShadow.lerpList(a.boxShadow, b.boxShadow, t),
         gradient: lerpGradient(t, a.gradient, b.gradient,
-            a.color ?? Color(0x00FFFFFF), b.color ?? Color(0x00FFFFFF)),
+            a.color ?? const Color(0x00FFFFFF), b.color ?? const Color(0x00FFFFFF)),
         shape: t < 0.5 ? a.shape : b.shape,
       );
     }
@@ -217,5 +216,6 @@ class SmoothDecorationTween extends DecorationTween {
         return Gradient.lerp(beginGradient, endGradient, t);
       }
     }
+    return null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/animated_box_decoration_test.dart
+++ b/test/animated_box_decoration_test.dart
@@ -4,9 +4,9 @@ import 'package:animated_box_decoration/animated_box_decoration.dart';
 
 void main() {
   test('adds one to input values', () {
-    final calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
+    // final calculator = Calculator();
+    // expect(calculator.addOne(2), 3);
+    // expect(calculator.addOne(-7), -6);
+    // expect(calculator.addOne(0), 1);
   });
 }


### PR DESCRIPTION
Removed many asserts with unneeded null checks
Added curly braces for if statements
Fixed incompatible line that fails iOS builds:
- EdgeInsetsGeometry? get padding => border?.dimensions;
+ EdgeInsetsGeometry get padding => border?.dimensions ?? EdgeInsets.zero; Added const where needed
Commented test file contents as Calculator is not known in this project Updated lint:
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1